### PR TITLE
[SciTokens] Switch the SciTokens checker to a dynamic module.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,11 @@ pkg_check_modules(GLOBUS REQUIRED globus-gsi-credential globus-gsi-cert-utils gl
 set (INCLUDE_DIRECTORIES ${INCLUDE_DIRECTORIES} ${GLOBUS_INCLUDE_DIRS})
 add_definitions(-DGLOBUS_AUTHZ)
 
+# Used to validate SciTokens.
+find_package( Boost REQUIRED COMPONENTS python )
+find_package( PythonLibs REQUIRED )
+find_package( PythonInterp REQUIRED )
+
 include_directories (${INCLUDE_DIRECTORIES} vjson)
 
 add_subdirectory (vjson)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,6 +10,9 @@ set (CVMFS_X509_HELPER_SOURCES
   x509_helper_voms.cc x509_helper_voms.h
   helper_utils.cc helper_utils.h
   scitoken_helper_fetch.cc scitoken_helper_fetch.cc
+  scitoken_helper_loader.cc scitoken_helper_loader.h)
+
+set (LIBCVMFS_X509_HELPER_SOURCES
   scitoken_helper_check.cc scitoken_helper_check.h)
 
 set (CVMFS_X509_VALIDATOR_SOURCES
@@ -18,6 +21,9 @@ set (CVMFS_X509_VALIDATOR_SOURCES
   x509_helper_log.cc x509_helper_log.h
   x509_helper_dynlib.cc x509_helper_dynlib.h
   x509_helper_voms.cc x509_helper_voms.h)
+
+add_library (libcvmfs_scitoken_helper MODULE ${LIBCVMFS_X509_HELPER_SOURCES})
+set_target_properties (libcvmfs_scitoken_helper PROPERTIES OUTPUT_NAME cvmfs_scitoken_helper)
 
 add_executable (cvmfs_x509_helper ${CVMFS_X509_HELPER_SOURCES})
 add_executable (cvmfs_scitoken_helper ${CVMFS_X509_HELPER_SOURCES})
@@ -32,6 +38,8 @@ install (
   TARGETS      cvmfs_x509_helper cvmfs_x509_validator cvmfs_scitoken_helper
   RUNTIME
   DESTINATION    libexec/cvmfs/authz
+  LIBRARY
+  DESTINATION    lib
 )
 
 

--- a/src/scitoken_helper_check.cc
+++ b/src/scitoken_helper_check.cc
@@ -13,6 +13,7 @@
 
 using namespace std;  // NOLINT
 
+__attribute__ ((visibility ("default")))
 StatusSciTokenValidation CheckSciToken(const string &membership, FILE *fp_token) {
   
   // At this point, fp_token points to the token file

--- a/src/scitoken_helper_check.h
+++ b/src/scitoken_helper_check.h
@@ -13,7 +13,12 @@ enum StatusSciTokenValidation {
   kCheckTokenInvalid,
 };
 
+typedef StatusSciTokenValidation (*CheckSciToken_t)(const std::string &membership,
+                                                    FILE *fp_token);
+
+extern "C" {
 StatusSciTokenValidation CheckSciToken(const std::string &membership,
-                                    FILE *fp_token);
+                                       FILE *fp_token);
+}
 
 #endif  // CVMFS_AUTHZ_SCITOKEN_HELPER_CHECK_H_

--- a/src/scitoken_helper_loader.cc
+++ b/src/scitoken_helper_loader.cc
@@ -1,0 +1,35 @@
+
+
+#include "x509_helper_dynlib.h"
+#include "scitoken_helper_loader.h"
+
+SciTokenLib *SciTokenLib::g_instance = NULL;
+SciTokenLibDestroyer SciTokenLib::g_destroyer;
+
+
+SciTokenLibDestroyer::~SciTokenLibDestroyer() {
+  if (m_instance) delete m_instance;
+}
+
+
+/**
+ * Load SciToken validation library.
+ * If successful, sets the global symbol appropriately.
+ */
+void
+SciTokenLib::Load() {
+  if (!OpenDynLib(&m_scitoken_check_handle,
+                  "libcvmfs_scitoken_helper.so",
+                  "SciToken checker")) {return;}
+
+  if (!LoadSymbol(m_scitoken_check_handle, &m_check_scitoken, "CheckSciToken"))
+  {
+    printf("Failed to load CheckSciToken symbol\n");
+  }
+}     
+
+
+void
+SciTokenLib::Close() {
+  CloseDynLib(&m_scitoken_check_handle, "SciToken checker");
+}

--- a/src/scitoken_helper_loader.h
+++ b/src/scitoken_helper_loader.h
@@ -1,0 +1,50 @@
+
+#include "scitoken_helper_check.h"
+
+
+class SciTokenLib;
+
+class SciTokenLibDestroyer {
+  friend class SciTokenLib;
+
+public:
+  SciTokenLibDestroyer() {m_instance = NULL;}
+  ~SciTokenLibDestroyer();
+
+private:
+  void set(SciTokenLib *instance) {m_instance = instance;}
+
+  SciTokenLib *m_instance;
+};
+
+class SciTokenLib {
+  friend class SciTokenLibDestroyer;
+
+public:
+  ~SciTokenLib() {Close();}
+
+  static CheckSciToken_t GetInstance() {
+    if (!g_instance) {
+      g_instance = new SciTokenLib();
+      g_destroyer.set(g_instance);
+    }
+
+    return g_instance->m_check_scitoken;
+  }
+
+private:
+  SciTokenLib() : m_scitoken_check_handle(NULL), m_check_scitoken(NULL)
+  {Load();}
+
+  SciTokenLib(const SciTokenLib&);
+  void Close();
+  void Load();
+
+  // Various library and symbol handles.
+  void *m_scitoken_check_handle;
+  CheckSciToken_t m_check_scitoken;
+
+  // Singleton instances
+  static SciTokenLib *g_instance;
+  static SciTokenLibDestroyer g_destroyer;
+};


### PR DESCRIPTION
The SciTokens helper will need to link to libpython and Boost, while the helper purposely keeps a minimal set of dependencies.

This should help us be able to keep the helpers on CVMFS itself.